### PR TITLE
Using assertSame to assert expected strictly

### DIFF
--- a/test/unit/ProtectedGlobalTest.php
+++ b/test/unit/ProtectedGlobalTest.php
@@ -8,9 +8,9 @@ use PHPUnit\Framework\TestCase;
 class ProtectedGlobalTest extends TestCase {
 	public function testToString() {
 		$sut = new ProtectedGlobal();
-		self::assertEquals(
+		self::assertSame(
 			ProtectedGlobal::WARNING_MESSAGE,
-			$sut
+			(string)$sut
 		);
 	}
 


### PR DESCRIPTION
# Changed log

As title, and fixing following issue:

```
PHPUnit 8.5.3 by Sebastian Bergmann and contributors.

F...........                                                      12 / 12 (100%)

Time: 39 ms, Memory: 4.00 MB

There was 1 failure:

1) Gt\ProtectedGlobal\Test\ProtectedGlobalTest::testToString
Failed asserting that Gt\ProtectedGlobal\ProtectedGlobal Object &0000000045514ba4000000000c9e6e7f (
    'whiteListData' => Array &0 ()
) is identical to 'Global variables are protected - see https://php.gt/globals'.

/data/ProtectedGlobal/test/unit/ProtectedGlobalTest.php:12

FAILURES!
Tests: 12, Assertions: 20, Failures: 1.

```